### PR TITLE
feat: support "before" configuration and add APISIX sandbox

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -61,6 +61,7 @@ type SandboxConfig struct {
 	User        string            `json:"user"`
 	Entrypoint  string            `json:"entrypoint"`
 	TimeoutRaw  int               `json:"timeout"`
+	Before      []string          `json:"before"`
 	Command     []string          `json:"command"`
 	Parameters  SandboxParameters `json:"parameters"`
 	Security    SandboxSecurity   `json:"security"`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -74,6 +74,27 @@ func (c *SandboxConfig) Timeout() time.Duration {
 	return time.Duration(c.TimeoutRaw) * time.Second
 }
 
+// RunCommand returns the initial command to run in the sandbox
+func (c *SandboxConfig) RunCommand() []string {
+	if len(c.Before) > 0 {
+		return c.Before
+	}
+	return c.Command
+}
+
+// ExecCommand returns the command to execute in a running sandbox
+func (c *SandboxConfig) ExecCommand() []string {
+	if len(c.Before) > 0 {
+		return c.Command
+	}
+	return nil
+}
+
+// Tty returns true if the sandbox should be run with a TTY
+func (c *SandboxConfig) Tty() bool {
+	return len(c.Before) > 0
+}
+
 // parseFileMode converts a string like "0755" into os.FileMode
 func parseFileMode(mode string) (os.FileMode, error) {
 	// Parse as base-8 (octal)

--- a/internal/sandbox/sandbox.go
+++ b/internal/sandbox/sandbox.go
@@ -206,6 +206,7 @@ func NewSandboxToolHandler(sandboxConfig *config.SandboxConfig) func(context.Con
 				AttachStderr: true,
 				User:         sandboxConfig.User,
 			}
+
 			execResp, err := cli.ContainerExecCreate(execCtx, resp.ID, execConfig)
 			if err != nil {
 				return nil, fmt.Errorf("failed to create exec: %v", err)
@@ -253,7 +254,6 @@ func NewSandboxToolHandler(sandboxConfig *config.SandboxConfig) func(context.Con
 		}
 
 		// Wait for execution to finish
-		// (This section only runs if useBefore is false)
 		statusCh, errCh := cli.ContainerWait(execCtx, resp.ID, container.WaitConditionNotRunning)
 		select {
 		case err := <-errCh:

--- a/internal/sandbox/sandbox.go
+++ b/internal/sandbox/sandbox.go
@@ -129,20 +129,13 @@ func NewSandboxToolHandler(sandboxConfig *config.SandboxConfig) func(context.Con
 		}
 		defer cli.Close()
 
-		// Decide what to use as the initial command
-		useBefore := len(sandboxConfig.Before) > 0
-		initialCmd := sandboxConfig.Command
-		if useBefore {
-			initialCmd = sandboxConfig.Before
-		}
-
 		// Create container config
 		containerConfig := &container.Config{
 			Image:      sandboxConfig.Image,
-			Cmd:        initialCmd,
+			Cmd:        sandboxConfig.RunCommand(),
 			WorkingDir: sandboxConfig.Mount.WorkDir,
 			User:       sandboxConfig.User,
-			Tty:        useBefore,
+			Tty:        sandboxConfig.Tty(),
 		}
 
 		// Create host config
@@ -200,7 +193,7 @@ func NewSandboxToolHandler(sandboxConfig *config.SandboxConfig) func(context.Con
 		}
 
 		// Only exec Command if Before was used to start the container
-		if useBefore {
+		if sandboxConfig.ExecCommand() != nil {
 
 			// Wait for container to be running
 			if err := waitForContainer(execCtx, cli, resp.ID, 10*time.Second); err != nil {

--- a/sandboxes/apisix/Dockerfile
+++ b/sandboxes/apisix/Dockerfile
@@ -1,0 +1,15 @@
+FROM apache/apisix:3.9.0-debian
+
+USER root
+
+RUN adduser --home /sandbox --disabled-password --gecos '' sandbox \
+    && chown -R sandbox:sandbox /usr/local/apisix/ \
+    && apt-get update -y \
+    && apt-get install -y curl \
+    && rm -rf /var/lib/apt/lists/*
+
+USER sandbox
+WORKDIR /sandbox
+
+COPY apisix.yaml /usr/local/apisix/conf/apisix.yaml
+COPY config.yaml /usr/local/apisix/conf/config.yaml

--- a/sandboxes/apisix/apisix.yaml
+++ b/sandboxes/apisix/apisix.yaml
@@ -1,0 +1,8 @@
+routes:
+  - id: init-apisix
+    uri: /anything/*
+    upstream:
+      nodes:
+        httpbin.org:80: 1
+      type: roundrobin
+#END

--- a/sandboxes/apisix/config.json
+++ b/sandboxes/apisix/config.json
@@ -1,0 +1,48 @@
+{
+	"name": "apisix",
+	"description": "Run a small, sandboxed instance of Apache APISIX, which can be configured through YAML and can be interacted through a curl command provided in main.sh. For example, curl -sI `http://127.0.0.1:9080` | grep Server",
+	"version": "0.1.0",
+	"image": "sandbox-mcp/apisix:latest",
+	"user": "sandbox",
+	"entrypoint": "main.sh",
+	"timeout": 60,
+	"before": [
+		"docker-start"
+	],
+	"command": [
+		"sh",
+		"-c",
+		"sleep 1 && mv -f apisix.yaml /usr/local/apisix/conf/apisix.yaml && sleep 1 && sh main.sh"
+	],
+	"parameters": {
+		"additionalFiles": true,
+		"files": [
+			{
+				"name": "apisix.yaml",
+				"description": "APISIX route configuration file"
+			}
+		]
+	},
+	"security": {
+		"readOnly": false,
+		"capDrop": [
+			"all"
+		],
+		"securityOpt": [
+			"no-new-privileges:true"
+		],
+		"network": "bridge"
+	},
+	"resources": {
+		"cpu": 1,
+		"memory": 256,
+		"processes": 256,
+		"files": 256
+	},
+	"mount": {
+		"workdir": "/sandbox",
+		"tmpdirPrefix": "sandbox-mcp-",
+		"scriptPerms": "0755",
+		"readOnly": false
+	}
+}

--- a/sandboxes/apisix/config.yaml
+++ b/sandboxes/apisix/config.yaml
@@ -1,0 +1,59 @@
+apisix:
+  node_listen:
+    - ip: 0.0.0.0
+      port: 9080
+  enable_admin: false
+  proxy_cache:
+    zones:
+      - name: disk_cache
+        memory_size: 2m
+        disk_size: 10m
+        disk_path: /tmp/disk_cache
+        cache_levels: 1:2
+nginx_config:
+  worker_rlimit_nofile: 128
+  event:
+    woker_connections: 32
+  meta:
+    lua_shared_dicts:
+      - prometheus_metrics: 1m
+  stream:
+    lua_shared_dict:
+      etcd-cluster-health-check-stream: 1m
+      lrucache-lock-stream: 1m
+      plugin-limit-conn-stream: 1m
+      worker-events-stream: 1m
+      tars-stream: 1m
+  http:
+    enable_access_log: false
+    access_log_buffer: 100
+    lua_shared_dict:
+      internal-status: 1m
+      plugin-limit-req: 1m
+      plugin-limit-count: 1m
+      prometheus-metrics: 1m
+      plugin-limit-conn: 1m
+      upstream-healthcheck: 1m
+      worker-events: 1m
+      lrucache-lock: 1m
+      balancer-ewma: 1m
+      balancer-ewma-locks: 1m
+      balancer-ewma-last-touched-at: 1m
+      plugin-limit-req-redis-cluster-slot-lock: 1m
+      plugin-limit-count-redis-cluster-slot-lock: 1m
+      plugin-limit-conn-redis-cluster-slot-lock: 1m
+      tracing_buffer: 1m
+      plugin-api-breaker: 1m
+      etcd-cluster-health-check: 1m
+      discovery: 1m
+      jwks: 1m
+      introspection: 1m
+      access-tokens: 1m
+      ext-plugin: 1m
+      tars: 1m
+      cas-auth: 1m
+      ocsp-stapling: 1m
+deployment:
+  role: data_plane
+  role_data_plane:
+    config_provider: yaml

--- a/sandboxes/apisix/config.yaml
+++ b/sandboxes/apisix/config.yaml
@@ -13,7 +13,7 @@ apisix:
 nginx_config:
   worker_rlimit_nofile: 128
   event:
-    woker_connections: 32
+    worker_connections: 32
   meta:
     lua_shared_dicts:
       - prometheus_metrics: 1m


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Adds a new `before` field to the sandbox configuration that lets you configure commands to run on container initialization before running the actual command sent by the clients.

This can be seen in the `apisix` sandbox added in this PR, where the `before` field specifies the command to start APISIX. So, before the clients send configurations and the `curl` commands, APISIX is initialized and running.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] New sandbox (entirely new sandbox that doesn't affect existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.