### PR TITLE
feat: properly format file names in response parameters

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -56,13 +57,21 @@ func (h *SandboxHints) IsExternalInteraction(securityNetwork string) bool {
 	return securityNetwork != "none"
 }
 
+// SandboxFile represents a file parameter
+type SandboxFile struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+// ParamName returns a safe parameter name for a file (replaces '.' with '_')
+func (f *SandboxFile) ParamName() string {
+	return strings.ReplaceAll(f.Name, ".", "_")
+}
+
 // SandboxParameters represents the parameters configuration
 type SandboxParameters struct {
-	AdditionalFiles bool `json:"additionalFiles"`
-	Files           []struct {
-		Name        string `json:"name"`
-		Description string `json:"description"`
-	} `json:"files,omitempty"`
+	AdditionalFiles bool          `json:"additionalFiles"`
+	Files           []SandboxFile `json:"files,omitempty"`
 }
 
 // SandboxSecurity represents the security configuration
@@ -124,6 +133,11 @@ func (c *SandboxConfig) Name() string {
 		return c.NameRaw
 	}
 	return c.Id
+}
+
+// ParamEntrypoint returns the entrypoint file name with proper formatting
+func (c *SandboxConfig) ParamEntrypoint() string {
+	return strings.ReplaceAll(c.Entrypoint, ".", "_")
 }
 
 // Timeout returns the timeout as a time.Duration

--- a/test/test_files/apisix.json
+++ b/test/test_files/apisix.json
@@ -1,8 +1,8 @@
 [
   {
     "request": {
-      "main.sh": "curl -sI \"http://127.0.0.1:9080\" | grep Server",
-      "apisix.yaml": "routes:\n  - id: 1\n    uri: /*\n    upstream:\n      nodes:\n        \"127.0.0.1:9001\": 1\n      type: roundrobin\n#END"
+      "main_sh": "curl -sI \"http://127.0.0.1:9080\" | grep Server",
+      "apisix_yaml": "routes:\n  - id: 1\n    uri: /*\n    upstream:\n      nodes:\n        \"127.0.0.1:9001\": 1\n      type: roundrobin\n#END"
     },
     "response": {
       "text": "Server: APISIX/3.9.0"
@@ -10,8 +10,8 @@
   },
   {
     "request": {
-      "main.sh": "curl -s \"http://127.0.0.1:9080/anything\"",
-      "apisix.yaml": "routes:\n  - id: 1\n    uri: /anything\n    plugins:\n      response-rewrite:\n        body: '{\"message\":\"Hello from APISIX!\"}'\n        headers:\n          content-type: application/json\n    upstream:\n      nodes:\n        \"httpbin.org:80\": 1\n      type: roundrobin\n#END"
+      "main_sh": "curl -s \"http://127.0.0.1:9080/anything\"",
+      "apisix_yaml": "routes:\n  - id: 1\n    uri: /anything\n    plugins:\n      response-rewrite:\n        body: '{\"message\":\"Hello from APISIX!\"}'\n        headers:\n          content-type: application/json\n    upstream:\n      nodes:\n        \"httpbin.org:80\": 1\n      type: roundrobin\n#END"
     },
     "response": {
       "text": "{\"message\":\"Hello from APISIX!\"}"
@@ -19,8 +19,8 @@
   },
   {
     "request": {
-      "main.sh": "curl -s \"http://127.0.0.1:9080/ip\"",
-      "apisix.yaml": "routes:\n  - id: 1\n    uri: /headers\n    upstream:\n      nodes:\n        \"httpbin.org:80\": 1\n      type: roundrobin\n#END"
+      "main_sh": "curl -s \"http://127.0.0.1:9080/ip\"",
+      "apisix_yaml": "routes:\n  - id: 1\n    uri: /headers\n    upstream:\n      nodes:\n        \"httpbin.org:80\": 1\n      type: roundrobin\n#END"
     },
     "response": {
       "text": "{\"error_msg\":\"404 Route Not Found\"}"
@@ -28,8 +28,8 @@
   },
   {
     "request": {
-      "main.sh": "curl -s \"http://127.0.0.1:9080/non-existent-path\"",
-      "apisix.yaml": "routes:\n  - id: 1\n    uri: /specific-path\n    upstream:\n      nodes:\n        \"httpbin.org:80\": 1\n      type: roundrobin\n#END"
+      "main_sh": "curl -s \"http://127.0.0.1:9080/non-existent-path\"",
+      "apisix_yaml": "routes:\n  - id: 1\n    uri: /specific-path\n    upstream:\n      nodes:\n        \"httpbin.org:80\": 1\n      type: roundrobin\n#END"
     },
     "response": {
       "text": "{\"error_msg\":\"404 Route Not Found\"}"
@@ -37,8 +37,8 @@
   },
   {
     "request": {
-      "main.sh": "curl -s \"http://127.0.0.1:9080/headers\"",
-      "apisix.yaml": "routes:\n  - id: 1\n    uri: /headers\n    upstream:\n      nodes:\n        \"httpbin.org:80\": 1\n      type: roundrobin\n#END"
+      "main_sh": "curl -s \"http://127.0.0.1:9080/headers\"",
+      "apisix_yaml": "routes:\n  - id: 1\n    uri: /headers\n    upstream:\n      nodes:\n        \"httpbin.org:80\": 1\n      type: roundrobin\n#END"
     },
     "response": {
       "text": "\"headers\":"
@@ -46,8 +46,8 @@
   },
   {
     "request": {
-      "main.sh": "curl -s \"http://127.0.0.1:9080/ip\" -H \"apikey: secret-key\"",
-      "apisix.yaml": "consumers:\n  - username: tom\n    plugins:\n      key-auth:\n        key: secret-key\n\nroutes:\n  - id: 1\n    uri: /ip\n    plugins:\n      key-auth: {}\n    upstream:\n      nodes:\n        \"httpbin.org:80\": 1\n      type: roundrobin\n#END"
+      "main_sh": "curl -s \"http://127.0.0.1:9080/ip\" -H \"apikey: secret-key\"",
+      "apisix_yaml": "consumers:\n  - username: tom\n    plugins:\n      key-auth:\n        key: secret-key\n\nroutes:\n  - id: 1\n    uri: /ip\n    plugins:\n      key-auth: {}\n    upstream:\n      nodes:\n        \"httpbin.org:80\": 1\n      type: roundrobin\n#END"
     },
     "response": {
       "text": "\"origin\":"

--- a/test/test_files/go.json
+++ b/test/test_files/go.json
@@ -1,8 +1,8 @@
 [
     {
         "request": {
-            "main.go": "package main\n\nimport \"fmt\"\n\nfunc main() {\n\tfmt.Println(\"hello!\")\n}",
-            "go.mod": "module example\n\ngo 1.19\n"
+            "main_go": "package main\n\nimport \"fmt\"\n\nfunc main() {\n\tfmt.Println(\"hello!\")\n}",
+            "go_mod": "module example\n\ngo 1.19\n"
         },
         "response": {
             "text": "hello!\n"
@@ -10,8 +10,8 @@
     },
     {
         "request": {
-            "main.go": "package main\n\nimport (\n\t\"fmt\"\n\t\"os\"\n\t\"io/ioutil\"\n)\n\nfunc main() {\n\tdata, err := ioutil.ReadFile(\"hello.txt\")\n\tif err != nil {\n\t\tfmt.Fprintf(os.Stderr, \"Error reading file: %v\\n\", err)\n\t\tos.Exit(1)\n\t}\n\tfmt.Print(string(data))\n}",
-            "go.mod": "module example\n\ngo 1.19\n",
+            "main_go": "package main\n\nimport (\n\t\"fmt\"\n\t\"os\"\n\t\"io/ioutil\"\n)\n\nfunc main() {\n\tdata, err := ioutil.ReadFile(\"hello.txt\")\n\tif err != nil {\n\t\tfmt.Fprintf(os.Stderr, \"Error reading file: %v\\n\", err)\n\t\tos.Exit(1)\n\t}\n\tfmt.Print(string(data))\n}",
+            "go_mod": "module example\n\ngo 1.19\n",
             "files": [
                 {
                     "filename": "hello.txt",
@@ -25,8 +25,8 @@
     },
     {
         "request": {
-            "main.go": "package main\n\nimport \"invalid/package\"\n\nfunc main() {\n\tfmt.Println(\"This won't compile\")\n}",
-            "go.mod": "module example\n\ngo 1.19\n"
+            "main_go": "package main\n\nimport \"invalid/package\"\n\nfunc main() {\n\tfmt.Println(\"This won't compile\")\n}",
+            "go_mod": "module example\n\ngo 1.19\n"
         },
         "response": {
             "text": "package invalid/package is not in std",

--- a/test/test_files/java.json
+++ b/test/test_files/java.json
@@ -1,7 +1,7 @@
 [
   {
     "request": {
-      "main.java": "public class Main {\n    public static void main(String[] args) {\n        System.out.println(\"hello!\");\n    }\n}"
+      "main_java": "public class Main {\n    public static void main(String[] args) {\n        System.out.println(\"hello!\");\n    }\n}"
     },
     "response": {
       "text": "hello!\n"
@@ -9,7 +9,7 @@
   },
   {
     "request": {
-      "main.java": "import java.io.IOException;\nimport java.nio.file.Files;\nimport java.nio.file.Paths;\n\npublic class Main {\n    public static void main(String[] args) {\n        try {\n            String content = new String(Files.readAllBytes(Paths.get(\"hello.txt\")));\n            System.out.print(content);\n        } catch (IOException e) {\n            System.err.println(\"Error reading file: \" + e.getMessage());\n        }\n    }\n}",
+      "main_java": "import java.io.IOException;\nimport java.nio.file.Files;\nimport java.nio.file.Paths;\n\npublic class Main {\n    public static void main(String[] args) {\n        try {\n            String content = new String(Files.readAllBytes(Paths.get(\"hello.txt\")));\n            System.out.print(content);\n        } catch (IOException e) {\n            System.err.println(\"Error reading file: \" + e.getMessage());\n        }\n    }\n}",
       "files": [
         {
           "filename": "hello.txt",
@@ -23,7 +23,7 @@
   },
   {
     "request": {
-      "main.java": "public class Main {\n    public static void main(String[] args) {\n        // This will not compile - undefined variable\n        System.out.println(undefinedVariable);\n    }\n}"
+      "main_java": "public class Main {\n    public static void main(String[] args) {\n        // This will not compile - undefined variable\n        System.out.println(undefinedVariable);\n    }\n}"
     },
     "response": {
       "text": "main.java:4: error: cannot find symbol\n        System.out.println(undefinedVariable);\n                           ^\n  symbol:   variable undefinedVariable\n  location: class Main\n1 error\nerror: compilation failed",
@@ -32,7 +32,7 @@
   },
   {
     "request": {
-      "main.java": "public class Main {\n    public static void main(String[] args) {\n        try {\n            // Intentional division by zero\n            int result = 10 / 0;\n            System.out.println(\"Result: \" + result);\n        } catch (ArithmeticException e) {\n            System.err.println(\"Caught exception: \" + e.getClass().getSimpleName() + \" - \" + e.getMessage());\n        }\n    }\n}"
+      "main_java": "public class Main {\n    public static void main(String[] args) {\n        try {\n            // Intentional division by zero\n            int result = 10 / 0;\n            System.out.println(\"Result: \" + result);\n        } catch (ArithmeticException e) {\n            System.err.println(\"Caught exception: \" + e.getClass().getSimpleName() + \" - \" + e.getMessage());\n        }\n    }\n}"
     },
     "response": {
       "text": "\nStderr:\nCaught exception: ArithmeticException - / by zero"
@@ -40,7 +40,7 @@
   },
   {
     "request": {
-      "main.java": "public class Main {\n    public static void main(String[] args) {\n        Person person = new Person(\"Alice\", 30);\n        System.out.println(person);\n    }\n}\n\nclass Person {\n    private String name;\n    private int age;\n    \n    public Person(String name, int age) {\n        this.name = name;\n        this.age = age;\n    }\n    \n    @Override\n    public String toString() {\n        return \"Person(name=\" + name + \", age=\" + age + \")\";\n    }\n}"
+      "main_java": "public class Main {\n    public static void main(String[] args) {\n        Person person = new Person(\"Alice\", 30);\n        System.out.println(person);\n    }\n}\n\nclass Person {\n    private String name;\n    private int age;\n    \n    public Person(String name, int age) {\n        this.name = name;\n        this.age = age;\n    }\n    \n    @Override\n    public String toString() {\n        return \"Person(name=\" + name + \", age=\" + age + \")\";\n    }\n}"
     },
     "response": {
       "text": "Person(name=Alice, age=30)\n"
@@ -48,7 +48,7 @@
   },
   {
     "request": {
-      "main.java": "public class Main {\n    public static void main(String[] args) {\n        // Test with regex pattern matching\n        String email = \"user@example.com\";\n        boolean isValid = email.matches(\"[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\\\.[a-zA-Z]{2,}\");\n        System.out.println(\"Email validation: \" + isValid);\n        \n        // Test with string manipulations\n        String text = \"Java Sandbox Test\";\n        System.out.println(\"Uppercase: \" + text.toUpperCase());\n        System.out.println(\"Length: \" + text.length());\n        System.out.println(\"Contains 'Sand': \" + text.contains(\"Sand\"));\n    }\n}"
+      "main_java": "public class Main {\n    public static void main(String[] args) {\n        // Test with regex pattern matching\n        String email = \"user@example.com\";\n        boolean isValid = email.matches(\"[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\\\.[a-zA-Z]{2,}\");\n        System.out.println(\"Email validation: \" + isValid);\n        \n        // Test with string manipulations\n        String text = \"Java Sandbox Test\";\n        System.out.println(\"Uppercase: \" + text.toUpperCase());\n        System.out.println(\"Length: \" + text.length());\n        System.out.println(\"Contains 'Sand': \" + text.contains(\"Sand\"));\n    }\n}"
     },
     "response": {
       "text": "Email validation: true\nUppercase: JAVA SANDBOX TEST\nLength: 17\nContains 'Sand': true\n"

--- a/test/test_files/javascript.json
+++ b/test/test_files/javascript.json
@@ -1,7 +1,7 @@
 [
   {
     "request": {
-      "index.js": "console.log(\"Hello from JavaScript!\");"
+      "index_js": "console.log(\"Hello from JavaScript!\");"
     },
     "response": {
       "text": "Hello from JavaScript!\n"
@@ -9,7 +9,7 @@
   },
   {
     "request": {
-      "index.js": "const fs = require('fs');\nconst content = fs.readFileSync('test_file.txt', 'utf8');\nconsole.log(content);",
+      "index_js": "const fs = require('fs');\nconst content = fs.readFileSync('test_file.txt', 'utf8');\nconsole.log(content);",
       "files": [
         {
           "filename": "test_file.txt",
@@ -23,7 +23,7 @@
   },
   {
     "request": {
-      "index.js": "const nonExistentFunction = require('non-existent-module');\nconsole.log(\"This won't execute\");"
+      "index_js": "const nonExistentFunction = require('non-existent-module');\nconsole.log(\"This won't execute\");"
     },
     "response": {
       "text": "Cannot find module 'non-existent-module'",
@@ -32,7 +32,7 @@
   },
   {
     "request": {
-      "index.js": "console.log(process.version);\nconsole.log(process.env.HOME);"
+      "index_js": "console.log(process.version);\nconsole.log(process.env.HOME);"
     },
     "response": {
       "text": "/sandbox"
@@ -40,7 +40,7 @@
   },
   {
     "request": {
-      "index.js": "throw new Error('Test error');"
+      "index_js": "throw new Error('Test error');"
     },
     "response": {
       "text": "Error: Test error",

--- a/test/test_files/network-tools.json
+++ b/test/test_files/network-tools.json
@@ -1,7 +1,7 @@
 [
   {
     "request": {
-      "main.sh": "ping -c 1 google.com"
+      "main_sh": "ping -c 1 google.com"
     },
     "response": {
       "text": "google.com ping statistics"
@@ -9,7 +9,7 @@
   },
   {
     "request": {
-      "main.sh": "nslookup google.com | head -n 5"
+      "main_sh": "nslookup google.com | head -n 5"
     },
     "response": {
       "text": "Server:"
@@ -17,7 +17,7 @@
   },
   {
     "request": {
-      "main.sh": "curl -s https://httpbin.org/get | head -n 5"
+      "main_sh": "curl -s https://httpbin.org/get | head -n 5"
     },
     "response": {
       "text": "\"args\":"
@@ -25,7 +25,7 @@
   },
   {
     "request": {
-      "main.sh": "ifconfig -a | head -n 3"
+      "main_sh": "ifconfig -a | head -n 3"
     },
     "response": {
       "text": "eth0: flags="
@@ -33,7 +33,7 @@
   },
   {
     "request": {
-      "main.sh": "non-existent-command"
+      "main_sh": "non-existent-command"
     },
     "response": {
       "text": "not found",

--- a/test/test_files/python.json
+++ b/test/test_files/python.json
@@ -1,7 +1,7 @@
 [
   {
     "request": {
-      "main.py": "print(\"Hello from Python!\")"
+      "main_py": "print(\"Hello from Python!\")"
     },
     "response": {
       "text": "Hello from Python!\n"
@@ -9,7 +9,7 @@
   },
   {
     "request": {
-      "main.py": "with open(\"test_file.txt\", \"r\") as f:\n    content = f.read()\n    print(content)",
+      "main_py": "with open(\"test_file.txt\", \"r\") as f:\n    content = f.read()\n    print(content)",
       "files": [
         {
           "filename": "test_file.txt",
@@ -23,7 +23,7 @@
   },
   {
     "request": {
-      "main.py": "import non_existent_module\nprint(\"This won't execute\")"
+      "main_py": "import non_existent_module\nprint(\"This won't execute\")"
     },
     "response": {
       "text": "ModuleNotFoundError: No module named 'non_existent_module'",
@@ -32,7 +32,7 @@
   },
   {
     "request": {
-      "main.py": "a = 1/0"
+      "main_py": "a = 1/0"
     },
     "response": {
       "text": "ZeroDivisionError: division by zero",
@@ -41,7 +41,7 @@
   },
   {
     "request": {
-      "main.py": "import sys\nprint(sys.version)\nimport os\nprint(os.environ.get('HOME'))"
+      "main_py": "import sys\nprint(sys.version)\nimport os\nprint(os.environ.get('HOME'))"
     },
     "response": {
       "text": "/sandbox"

--- a/test/test_files/rust.json
+++ b/test/test_files/rust.json
@@ -1,7 +1,7 @@
 [
   {
     "request": {
-      "main.rs": "fn main() {\n    println!(\"hello!\");\n}"
+      "main_rs": "fn main() {\n    println!(\"hello!\");\n}"
     },
     "response": {
       "text": "hello!\n"
@@ -9,7 +9,7 @@
   },
   {
     "request": {
-      "main.rs": "use std::fs;\n\nfn main() {\n    match fs::read_to_string(\"hello.txt\") {\n        Ok(content) => print!(\"{}\", content),\n        Err(e) => eprintln!(\"Error reading file: {}\", e),\n    }\n}",
+      "main_rs": "use std::fs;\n\nfn main() {\n    match fs::read_to_string(\"hello.txt\") {\n        Ok(content) => print!(\"{}\", content),\n        Err(e) => eprintln!(\"Error reading file: {}\", e),\n    }\n}",
       "files": [
         {
           "filename": "hello.txt",
@@ -23,7 +23,7 @@
   },
   {
     "request": {
-      "main.rs": "use invalid_package;\n\nfn main() {\n    println!(\"This won't compile\");\n}"
+      "main_rs": "use invalid_package;\n\nfn main() {\n    println!(\"This won't compile\");\n}"
     },
     "response": {
       "text": "error[E0432]: unresolved import `invalid_package`\n --> main.rs:1:5\n  |\n1 | use invalid_package;\n  |     ^^^^^^^^^^^^^^^ no `invalid_package` in the root\n\nerror: aborting due to 1 previous error\n\nFor more information about this error, try `rustc --explain E0432`.",
@@ -32,7 +32,7 @@
   },
   {
     "request": {
-      "main.rs": "#[derive(Debug)]\nstruct Person {\n    name: String,\n    age: u8,\n}\n\nfn main() {\n    let person = Person {\n        name: String::from(\"Alice\"),\n        age: 30,\n    };\n    \n    println!(\"{:?}\", person);\n}"
+      "main_rs": "#[derive(Debug)]\nstruct Person {\n    name: String,\n    age: u8,\n}\n\nfn main() {\n    let person = Person {\n        name: String::from(\"Alice\"),\n        age: 30,\n    };\n    \n    println!(\"{:?}\", person);\n}"
     },
     "response": {
       "text": "Person { name: \"Alice\", age: 30 }"
@@ -40,7 +40,7 @@
   },
   {
     "request": {
-      "main.rs": "use std::fs;\n\nfn main() {\n    match fs::read_to_string(\"nonexistent_file.txt\") {\n        Ok(content) => println!(\"Content: {}\", content),\n        Err(e) => eprintln!(\"Error: {}\", e),\n    }\n}"
+      "main_rs": "use std::fs;\n\nfn main() {\n    match fs::read_to_string(\"nonexistent_file.txt\") {\n        Ok(content) => println!(\"Content: {}\", content),\n        Err(e) => eprintln!(\"Error: {}\", e),\n    }\n}"
     },
     "response": {
       "text": "Stderr:\nError: No such file or directory (os error 2)",
@@ -49,7 +49,7 @@
   },
   {
     "request": {
-      "main.rs": "fn main() {\n    let mut numbers = vec![1, 2, 3, 4, 5];\n    numbers.push(6);\n    \n    let sum: i32 = numbers.iter().sum();\n    println!(\"Sum: {}\", sum);\n    \n    let doubled: Vec<i32> = numbers.iter().map(|&x| x * 2).collect();\n    println!(\"Doubled: {:?}\", doubled);\n}"
+      "main_rs": "fn main() {\n    let mut numbers = vec![1, 2, 3, 4, 5];\n    numbers.push(6);\n    \n    let sum: i32 = numbers.iter().sum();\n    println!(\"Sum: {}\", sum);\n    \n    let doubled: Vec<i32> = numbers.iter().map(|&x| x * 2).collect();\n    println!(\"Doubled: {:?}\", doubled);\n}"
     },
     "response": {
       "text": "Sum: 21\nDoubled: [2, 4, 6, 8, 10, 12]\n"
@@ -57,7 +57,7 @@
   },
   {
     "request": {
-      "main.rs": "fn main() {\n    // Test more complex error handling with Result and Option\n    let result: Result<i32, &str> = Err(\"something went wrong\");\n    \n    if let Err(e) = result {\n        eprintln!(\"Error occurred: {}\", e);\n    }\n    \n    // Testing Option\n    let some_value: Option<i32> = Some(42);\n    let none_value: Option<i32> = None;\n    \n    println!(\"Some value: {}\", some_value.unwrap_or(0));\n    println!(\"None value: {}\", none_value.unwrap_or(0));\n}"
+      "main_rs": "fn main() {\n    // Test more complex error handling with Result and Option\n    let result: Result<i32, &str> = Err(\"something went wrong\");\n    \n    if let Err(e) = result {\n        eprintln!(\"Error occurred: {}\", e);\n    }\n    \n    // Testing Option\n    let some_value: Option<i32> = Some(42);\n    let none_value: Option<i32> = None;\n    \n    println!(\"Some value: {}\", some_value.unwrap_or(0));\n    println!(\"None value: {}\", none_value.unwrap_or(0));\n}"
     },
     "response": {
       "text": "Some value: 42\nNone value: 0\n\nStderr:\nError occurred: something went wrong"
@@ -65,7 +65,7 @@
   },
   {
     "request": {
-      "main.rs": "use std::sync::mpsc;\nuse std::thread;\n\nfn main() {\n    let (tx, rx) = mpsc::channel();\n    \n    thread::spawn(move || {\n        tx.send(\"Hello from another thread!\").unwrap();\n    });\n    \n    let received = rx.recv().unwrap();\n    println!(\"{}\", received);\n}"
+      "main_rs": "use std::sync::mpsc;\nuse std::thread;\n\nfn main() {\n    let (tx, rx) = mpsc::channel();\n    \n    thread::spawn(move || {\n        tx.send(\"Hello from another thread!\").unwrap();\n    });\n    \n    let received = rx.recv().unwrap();\n    println!(\"{}\", received);\n}"
     },
     "response": {
       "text": "Hello from another thread!\n"

--- a/test/test_files/shell.json
+++ b/test/test_files/shell.json
@@ -1,7 +1,7 @@
 [
     {
         "request": {
-            "main.sh": "echo hello!"
+            "main_sh": "echo hello!"
         },
         "response": {
             "text": "hello!\n"
@@ -9,7 +9,7 @@
     },
     {
         "request": {
-            "main.sh": "cat hello.txt",
+            "main_sh": "cat hello.txt",
             "files": [
                 {
                     "filename": "hello.txt",
@@ -23,7 +23,7 @@
     },
     {
         "request": {
-            "main.sh": "invalid-command"
+            "main_sh": "invalid-command"
         },
         "response": {
             "text": "not found",


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Previously, the parameters in the JSON schema provided by the server had keys like `main.sh` and `main.go` which is bad for MCP clients like Cursor. Now it has been replaced by `main_sh` and `main_go` which maps to their respective filenames in the sandbox.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New sandbox (entirely new sandbox that doesn't affect existing functionality)
- [x] I have added tests to cover my changes
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.